### PR TITLE
Update GIT_TAG for googletest

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 include(DownloadProject.cmake)
 download_project(PROJ                googletest
                  GIT_REPOSITORY      https://github.com/google/googletest.git
-                 GIT_TAG             master
+                 GIT_TAG             main
                  ${UPDATE_DISCONNECTED_IF_AVAILABLE}
                  QUIET
 )


### PR DESCRIPTION
googletest repo changed their branch name from "master" to "main" (see [#3669](https://github.com/google/googletest/pull/3669)). This causes a cmake error when trying to build the code from source. 

Easy fix by changing the name the GIT_TAG to main so that cmake clones the right branch. 